### PR TITLE
Warning Hours work the other way round

### DIFF
--- a/Database/ModTweakables.xml
+++ b/Database/ModTweakables.xml
@@ -46,7 +46,7 @@
     </GameDBTweakableFloat>
 
     <GameDBTweakableFloat ID="TWEAKABLE_PATIENT_LEAVE_WARNING_HOURS">
-        <Value>236.0</Value>
+        <Value>4.0</Value>
     </GameDBTweakableFloat>
 
     <GameDBTweakableFloat ID="TWEAKABLE_PATIENT_MAX_WAIT_TIME_HOURS">


### PR DESCRIPTION
from looking at the vanilla config and from playing experience, I'd say TWEAKABLE_PATIENT_LEAVE_WARNING_HOURS works just the other way round: it's the number of hours that's deducted from
TWEAKABLE_PATIENT_LEAVE_TIME_HOURS and when a patient is that long in your hospital you'll get the warning.